### PR TITLE
fixed issue with displaying return results for only one record

### DIFF
--- a/abnClass.rb
+++ b/abnClass.rb
@@ -4,33 +4,30 @@ require "savon"
 # Just updating this one line
 class ABN
 	attr_reader :value
-	attr_reader :search_type
+	attr_reader :rec_count
 
-	def initialize(val=0, type="Number")
+	def initialize(val = 0, count = 0)
 		@value = val
-		@search_type = type
+		@rec_count = count
 	end
 
 	def load_search
 			print "\nEnter the ABN you are searching for: "
 			@value = gets.chomp
-			if @value =~ /^\d{11}$/
-				@search_type = "Number"
-			else
-				@search_type = "Name"
-			end
 	end
 
 	def search_abr
 		guid = "890b3a4c-7267-4c8f-8c43-825a349a5e87"
 		client = Savon.client(wsdl: "http://www.abn.business.gov.au/abrxmlsearch/ABRXMLSearch.asmx?WSDL")
 
-		if @search_type == "Number"
+		if @value =~ /^\d{11}$/
 			response = client.call(:abr_search_by_abn, message: { authenticationGuid: guid, searchString: @value, includeHistoricalDetails: "N" })
 			response.body[:abr_search_by_abn_response][:abr_payload_search_results][:response][:business_entity]
 		else
 			response = client.call(:abr_search_by_name_simple_protocol, message: { name: @value, authenticationGuid: guid })
+			@rec_count = response.body[:abr_search_by_name_simple_protocol_response][:abr_payload_search_results][:response][:search_results_list][:number_of_records]
 			response.body[:abr_search_by_name_simple_protocol_response][:abr_payload_search_results][:response][:search_results_list][:search_results_record]
+
 		end
 
 	end

--- a/abnGet.rb
+++ b/abnGet.rb
@@ -1,13 +1,13 @@
 require_relative 'abnClass'
 
 begin
-  myabn = ABN.new(97000098162,"Number")
+  myabn = ABN.new(97000098162,0)
 
   status = myabn.load_search
 
   abn_details = myabn.search_abr
 
-  if myabn.search_type == 'Number'
+  if (myabn.value =~ /^\d{11}$/) || (myabn.rec_count == '1')
     myabn.output_abn_search(abn_details)
   else
     myabn.output_name_search(abn_details)


### PR DESCRIPTION
This fixes an issue whereby when name-search was used and only one record was returned, the display would fail.